### PR TITLE
Update toDI to use argument

### DIFF
--- a/exactReal.hs
+++ b/exactReal.hs
@@ -164,7 +164,7 @@ data DualInterval = !Interval :+& !Interval
   deriving (Eq, Show)
 
 -- redefinition of function on dual intervals 
-toDI i = toI 1 :+& toI 0
+toDI i = toI i :+& toI 0
 
 multExp2DI (xa :+& xi) n =  multExp2I xa n :+&  multExp2I xi n
 


### PR DESCRIPTION
## Summary
- make `toDI` use its integer argument rather than a fixed `1`

## Testing
- `ghc -fno-code exactReal.hs` *(fails: Could not find module `Math.NumberTheory.Logarithms`)*

------
https://chatgpt.com/codex/tasks/task_e_6841433b7ab0832996f072e3854e5d2c